### PR TITLE
Prerelease updates

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
 Werkzeug==3.0.6
 gunicorn==23.0.0
-pytest==6.2.5
+pytest==7.2.2


### PR DESCRIPTION
This pull request updates the Python version used in the Docker image and GitHub Actions workflow to Python 3.11.

Updates to Python version:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL49-R49): Updated the Python version from 3.9 to 3.11 in the GitHub Actions workflow.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the base image from `python:3.9-slim` to `python:3.11-slim`.